### PR TITLE
Added Mouser and LCSC Numbers. Updated to KiCad 9

### DIFF
--- a/HVI.kicad_pro
+++ b/HVI.kicad_pro
@@ -70,16 +70,19 @@
         "copper_edge_clearance": "error",
         "copper_sliver": "warning",
         "courtyards_overlap": "warning",
+        "creepage": "error",
         "diff_pair_gap_out_of_range": "error",
         "diff_pair_uncoupled_length_too_long": "error",
         "drill_out_of_range": "error",
         "duplicate_footprints": "warning",
         "extra_footprint": "warning",
         "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
         "footprint_symbol_mismatch": "warning",
         "footprint_type_mismatch": "error",
         "hole_clearance": "error",
         "hole_near_hole": "error",
+        "hole_to_hole": "error",
         "holes_co_located": "warning",
         "invalid_outline": "error",
         "isolated_copper": "warning",
@@ -90,9 +93,11 @@
         "lib_footprint_mismatch": "ignore",
         "malformed_courtyard": "error",
         "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
         "missing_courtyard": "ignore",
         "missing_footprint": "warning",
         "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
         "npth_inside_courtyard": "warning",
         "padstack": "error",
         "pth_inside_courtyard": "warning",
@@ -104,10 +109,13 @@
         "solder_mask_bridge": "error",
         "starved_thermal": "error",
         "text_height": "ignore",
+        "text_on_edge_cuts": "error",
         "text_thickness": "ignore",
         "through_hole_pad_without_hole": "error",
         "too_many_vias": "error",
+        "track_angle": "error",
         "track_dangling": "warning",
+        "track_segment_length": "error",
         "track_width": "error",
         "tracks_crossing": "error",
         "unconnected_items": "error",
@@ -122,6 +130,7 @@
         "min_clearance": 0.0,
         "min_connection": 0.0,
         "min_copper_edge_clearance": 0.0,
+        "min_groove_width": 0.0,
         "min_hole_clearance": 0.25,
         "min_hole_to_hole": 0.25,
         "min_microvia_diameter": 0.2,
@@ -141,10 +150,11 @@
       },
       "teardrop_options": [
         {
-          "td_onpadsmd": true,
+          "td_onpthpad": true,
           "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
           "td_ontrackend": false,
-          "td_onviapad": true
+          "td_onvia": true
         }
       ],
       "teardrop_parameters": [
@@ -238,6 +248,7 @@
       "mfg": "",
       "mpn": ""
     },
+    "layer_pairs": [],
     "layer_presets": [],
     "viewports": []
   },
@@ -432,10 +443,15 @@
       "duplicate_sheet_names": "error",
       "endpoint_off_grid": "warning",
       "extra_units": "error",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
       "global_label_dangling": "warning",
       "hier_label_mismatch": "error",
       "label_dangling": "error",
+      "label_multiple_wires": "warning",
       "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
       "missing_bidi_pin": "warning",
       "missing_input_pin": "warning",
       "missing_power_pin": "error",
@@ -448,9 +464,14 @@
       "pin_not_driven": "error",
       "pin_to_pin": "warning",
       "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
       "similar_labels": "warning",
+      "similar_power": "warning",
       "simulation_model_issue": "error",
+      "single_global_label": "ignore",
       "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
       "unit_value_mismatch": "error",
       "unresolved_variable": "error",
       "wire_dangling": "error"
@@ -462,7 +483,7 @@
   },
   "meta": {
     "filename": "HVI.kicad_pro",
-    "version": 1
+    "version": 3
   },
   "net_settings": {
     "classes": [
@@ -477,6 +498,7 @@
         "microvia_drill": 0.1,
         "name": "Default",
         "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
         "schematic_color": "rgba(0, 0, 0, 0.000)",
         "track_width": 0.5,
         "via_diameter": 0.8,
@@ -485,7 +507,7 @@
       }
     ],
     "meta": {
-      "version": 3
+      "version": 4
     },
     "net_colors": null,
     "netclass_assignments": null,
@@ -520,7 +542,7 @@
     },
     "bom_presets": [],
     "bom_settings": {
-      "exclude_dnp": false,
+      "exclude_dnp": true,
       "fields_ordered": [
         {
           "group_by": false,
@@ -536,26 +558,26 @@
         },
         {
           "group_by": false,
-          "label": "Datasheet",
-          "name": "Datasheet",
-          "show": true
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": false
         },
         {
           "group_by": false,
-          "label": "Footprint",
-          "name": "Footprint",
-          "show": true
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": false
+        },
+        {
+          "group_by": false,
+          "label": "Description",
+          "name": "Description",
+          "show": false
         },
         {
           "group_by": false,
           "label": "Qty",
           "name": "${QUANTITY}",
-          "show": true
-        },
-        {
-          "group_by": true,
-          "label": "DNP",
-          "name": "${DNP}",
           "show": true
         },
         {
@@ -580,6 +602,18 @@
           "group_by": false,
           "label": "Manufacturer Number",
           "name": "Manufacturer Number",
+          "show": false
+        },
+        {
+          "group_by": false,
+          "label": "LCSC",
+          "name": "LCSC",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Mouser",
+          "name": "Mouser",
           "show": true
         },
         {
@@ -620,16 +654,17 @@
         },
         {
           "group_by": false,
-          "label": "Description",
-          "name": "Description",
+          "label": "DNP",
+          "name": "${DNP}",
           "show": false
         }
       ],
       "filter_string": "",
       "group_symbols": true,
+      "include_excluded_from_bom": false,
       "name": "",
       "sort_asc": true,
-      "sort_field": "Reference"
+      "sort_field": "Mouser"
     },
     "connection_grid_size": 50.0,
     "drawing": {
@@ -670,6 +705,7 @@
     },
     "page_layout_descr_file": "",
     "plot_directory": "",
+    "space_save_all_events": true,
     "spice_adjust_passive_values": false,
     "spice_current_sheet_as_root": false,
     "spice_external_command": "spice \"%I\"",

--- a/HVI.kicad_sch
+++ b/HVI.kicad_sch
@@ -1,7 +1,7 @@
 (kicad_sch
-	(version 20231120)
+	(version 20250114)
 	(generator "eeschema")
-	(generator_version "8.0")
+	(generator_version "9.0")
 	(uuid "96589b0c-b051-494a-952b-1d85eb492735")
 	(paper "A4")
 	(title_block
@@ -11,7 +11,9 @@
 	(lib_symbols
 		(symbol "Conn_01x02_1"
 			(pin_names
-				(offset 1.016) hide)
+				(offset 1.016)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -80,14 +82,14 @@
 			)
 			(symbol "Conn_01x02_1_1_1"
 				(rectangle
-					(start -1.27 -2.413)
-					(end 0 -2.667)
+					(start -1.27 1.27)
+					(end 1.27 -3.81)
 					(stroke
-						(width 0.1524)
+						(width 0.254)
 						(type default)
 					)
 					(fill
-						(type none)
+						(type background)
 					)
 				)
 				(rectangle
@@ -102,14 +104,14 @@
 					)
 				)
 				(rectangle
-					(start -1.27 1.27)
-					(end 1.27 -3.81)
+					(start -1.27 -2.413)
+					(end 0 -2.667)
 					(stroke
-						(width 0.254)
+						(width 0.1524)
 						(type default)
 					)
 					(fill
-						(type background)
+						(type none)
 					)
 				)
 				(pin passive line
@@ -149,10 +151,13 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Connector:Conn_01x01_Socket"
 			(pin_names
-				(offset 1.016) hide)
+				(offset 1.016)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -239,9 +244,9 @@
 					)
 				)
 				(arc
-					(start 0 0.508)
+					(start 0 -0.508)
 					(mid -0.5058 0)
-					(end 0 -0.508)
+					(end 0 0.508)
 					(stroke
 						(width 0.1524)
 						(type default)
@@ -269,10 +274,13 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Connector_Generic:Conn_01x02"
 			(pin_names
-				(offset 1.016) hide)
+				(offset 1.016)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -339,14 +347,14 @@
 			)
 			(symbol "Conn_01x02_1_1"
 				(rectangle
-					(start -1.27 -2.413)
-					(end 0 -2.667)
+					(start -1.27 1.27)
+					(end 1.27 -3.81)
 					(stroke
-						(width 0.1524)
+						(width 0.254)
 						(type default)
 					)
 					(fill
-						(type none)
+						(type background)
 					)
 				)
 				(rectangle
@@ -361,14 +369,14 @@
 					)
 				)
 				(rectangle
-					(start -1.27 1.27)
-					(end 1.27 -3.81)
+					(start -1.27 -2.413)
+					(end 0 -2.667)
 					(stroke
-						(width 0.254)
+						(width 0.1524)
 						(type default)
 					)
 					(fill
-						(type background)
+						(type none)
 					)
 				)
 				(pin passive line
@@ -408,6 +416,7 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Converter_DCDC:PEME1-S5-S5-S"
 			(pin_names
@@ -551,24 +560,6 @@
 						)
 					)
 				)
-				(pin passive line
-					(at 15.24 -2.54 180)
-					(length 5.08)
-					(name "0V"
-						(effects
-							(font
-								(size 1.016 1.016)
-							)
-						)
-					)
-					(number "5"
-						(effects
-							(font
-								(size 1.016 1.016)
-							)
-						)
-					)
-				)
 				(pin output line
 					(at 15.24 2.54 180)
 					(length 5.08)
@@ -587,7 +578,26 @@
 						)
 					)
 				)
+				(pin passive line
+					(at 15.24 -2.54 180)
+					(length 5.08)
+					(name "0V"
+						(effects
+							(font
+								(size 1.016 1.016)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.016 1.016)
+							)
+						)
+					)
+				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "DC-DC Symbol Lib:VIPer06-SSOP-10"
 			(exclude_from_sim no)
@@ -668,24 +678,6 @@
 						(type background)
 					)
 				)
-				(pin power_in line
-					(at -6.35 -10.16 90)
-					(length 2.54)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin passive line
 					(at -6.35 5.08 270)
 					(length 2.54)
@@ -697,6 +689,100 @@
 						)
 					)
 					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -6.35 5.08 270)
+					(length 2.54)
+					(hide yes)
+					(name "DRAIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -6.35 5.08 270)
+					(length 2.54)
+					(hide yes)
+					(name "DRAIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -6.35 5.08 270)
+					(length 2.54)
+					(hide yes)
+					(name "DRAIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -6.35 5.08 270)
+					(length 2.54)
+					(hide yes)
+					(name "DRAIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -6.35 -10.16 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -740,24 +826,6 @@
 						)
 					)
 				)
-				(pin input line
-					(at 5.08 -10.16 90)
-					(length 2.54)
-					(name "FB"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin passive line
 					(at 5.08 5.08 270)
 					(length 2.54)
@@ -776,71 +844,17 @@
 						)
 					)
 				)
-				(pin passive line
-					(at -6.35 5.08 270)
-					(length 2.54) hide
-					(name "DRAIN"
+				(pin input line
+					(at 5.08 -10.16 90)
+					(length 2.54)
+					(name "FB"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 5.08 270)
-					(length 2.54) hide
-					(name "DRAIN"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 5.08 270)
-					(length 2.54) hide
-					(name "DRAIN"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 5.08 270)
-					(length 2.54) hide
-					(name "DRAIN"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "9"
+					(number "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -849,11 +863,16 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:C_Small"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
-				(offset 0.254) hide)
+				(offset 0.254)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -923,10 +942,10 @@
 			(symbol "C_Small_0_1"
 				(polyline
 					(pts
-						(xy -1.524 -0.508) (xy 1.524 -0.508)
+						(xy -1.524 0.508) (xy 1.524 0.508)
 					)
 					(stroke
-						(width 0.3302)
+						(width 0.3048)
 						(type default)
 					)
 					(fill
@@ -935,10 +954,10 @@
 				)
 				(polyline
 					(pts
-						(xy -1.524 0.508) (xy 1.524 0.508)
+						(xy -1.524 -0.508) (xy 1.524 -0.508)
 					)
 					(stroke
-						(width 0.3048)
+						(width 0.3302)
 						(type default)
 					)
 					(fill
@@ -984,11 +1003,16 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:D_Small"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
-				(offset 0.254) hide)
+				(offset 0.254)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -1058,10 +1082,10 @@
 			(symbol "D_Small_0_1"
 				(polyline
 					(pts
-						(xy -0.762 -1.016) (xy -0.762 1.016)
+						(xy -0.762 0) (xy 0.762 0)
 					)
 					(stroke
-						(width 0.254)
+						(width 0)
 						(type default)
 					)
 					(fill
@@ -1070,10 +1094,10 @@
 				)
 				(polyline
 					(pts
-						(xy -0.762 0) (xy 0.762 0)
+						(xy -0.762 -1.016) (xy -0.762 1.016)
 					)
 					(stroke
-						(width 0)
+						(width 0.254)
 						(type default)
 					)
 					(fill
@@ -1131,9 +1155,12 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:Fuse"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
 				(offset 0)
 			)
@@ -1264,11 +1291,16 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:LED"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
-				(offset 1.016) hide)
+				(offset 1.016)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -1336,10 +1368,22 @@
 			(symbol "LED_0_1"
 				(polyline
 					(pts
-						(xy -1.27 -1.27) (xy -1.27 1.27)
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
 					)
 					(stroke
-						(width 0.254)
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
 						(type default)
 					)
 					(fill
@@ -1360,7 +1404,7 @@
 				)
 				(polyline
 					(pts
-						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+						(xy -1.27 -1.27) (xy -1.27 1.27)
 					)
 					(stroke
 						(width 0.254)
@@ -1372,22 +1416,10 @@
 				)
 				(polyline
 					(pts
-						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
 					)
 					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
-					)
-					(stroke
-						(width 0)
+						(width 0.254)
 						(type default)
 					)
 					(fill
@@ -1433,11 +1465,16 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:L_Small"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
-				(offset 0.254) hide)
+				(offset 0.254)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -1506,32 +1543,8 @@
 			)
 			(symbol "L_Small_0_1"
 				(arc
-					(start 0 -2.032)
-					(mid 0.5058 -1.524)
-					(end 0 -1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start 0 -1.016)
-					(mid 0.5058 -0.508)
-					(end 0 0)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start 0 0)
-					(mid 0.5058 0.508)
+					(start 0 2.032)
+					(mid 0.5058 1.524)
 					(end 0 1.016)
 					(stroke
 						(width 0)
@@ -1543,8 +1556,32 @@
 				)
 				(arc
 					(start 0 1.016)
-					(mid 0.5058 1.524)
-					(end 0 2.032)
+					(mid 0.5058 0.508)
+					(end 0 0)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start 0 0)
+					(mid 0.5058 -0.508)
+					(end 0 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start 0 -1.016)
+					(mid 0.5058 -1.524)
+					(end 0 -2.032)
 					(stroke
 						(width 0)
 						(type default)
@@ -1592,9 +1629,12 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:R"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
 				(offset 0)
 			)
@@ -1713,11 +1753,16 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Device:R_Small"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
-				(offset 0.254) hide)
+				(offset 0.254)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -1835,11 +1880,16 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Diode:SM6T6V8A"
-			(pin_numbers hide)
+			(pin_numbers
+				(hide yes)
+			)
 			(pin_names
-				(offset 1.016) hide)
+				(offset 1.016)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -1968,10 +2018,13 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
 		(symbol "Jumper:SolderJumper_3_Open"
 			(pin_names
-				(offset 0) hide)
+				(offset 0)
+				(hide yes)
+			)
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -2037,41 +2090,6 @@
 				)
 			)
 			(symbol "SolderJumper_3_Open_0_1"
-				(arc
-					(start -1.016 1.016)
-					(mid -2.0276 0)
-					(end -1.016 -1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start -1.016 1.016)
-					(mid -2.0276 0)
-					(end -1.016 -1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-				(rectangle
-					(start -0.508 1.016)
-					(end 0.508 -1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
 				(polyline
 					(pts
 						(xy -2.54 0) (xy -2.032 0)
@@ -2096,6 +2114,41 @@
 						(type none)
 					)
 				)
+				(arc
+					(start -1.016 -1.016)
+					(mid -2.0276 0)
+					(end -1.016 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -1.016 -1.016)
+					(mid -2.0276 0)
+					(end -1.016 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -0.508 1.016)
+					(end 0.508 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
 				(polyline
 					(pts
 						(xy 0 -1.27) (xy 0 -1.016)
@@ -2106,6 +2159,30 @@
 					)
 					(fill
 						(type none)
+					)
+				)
+				(arc
+					(start 1.016 1.016)
+					(mid 2.0276 0)
+					(end 1.016 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start 1.016 1.016)
+					(mid 2.0276 0)
+					(end 1.016 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
 					)
 				)
 				(polyline
@@ -2130,30 +2207,6 @@
 					)
 					(fill
 						(type none)
-					)
-				)
-				(arc
-					(start 1.016 -1.016)
-					(mid 2.0276 0)
-					(end 1.016 1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(arc
-					(start 1.016 -1.016)
-					(mid 2.0276 0)
-					(end 1.016 1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type outline)
 					)
 				)
 			)
@@ -2213,7 +2266,292 @@
 					)
 				)
 			)
+			(embedded_fonts no)
 		)
+	)
+	(text "Note on C11\nIf it is intend to drive a large load, \nthen you can use C11 instead."
+		(exclude_from_sim no)
+		(at 153.67 77.47 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+				(thickness 0.2)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "01fc083c-ae87-47fd-a618-378415834db0")
+	)
+	(text "I'm unsure why 700 V and 800 V look so different from the others.\nMight need to re-test when I got time :‘)"
+		(exclude_from_sim no)
+		(at 240.665 92.075 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+				(thickness 0.12)
+				(bold yes)
+			)
+		)
+		(uuid "1c91fa15-c22c-4582-8b12-0e494b25a2e4")
+	)
+	(text "Buck converter using VIPER06\n800V -> 5V/12V "
+		(exclude_from_sim no)
+		(at 15.24 24.765 0)
+		(effects
+			(font
+				(size 3 3)
+				(thickness 0.6)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "2f65ae9a-ff30-4504-9336-cdcf2f6fc423")
+	)
+	(text "FAQ:\n\nQ: 	Why are 2x 4.7 mH inductors used instead of a 10 mH inductor?\nA: 	You will rarely find maximum voltage values for SMD inductors, so just an extra precaution.\n\nQ: 	Why is there no output fuse?\nA: 	The VIPER06 can be short-circuited indefinitely.\n\nQ: 	I need [insert voltage here], can I do that?\nA: 	You can either change PS1 (12 V to 3.3 V to 24 V converters available) \n	or (when used directly without PS1) the feedback voltage divider can be altered.\n	I do not reccomend going above 23.5 V because the IC's VDD voltage will be clamped, \n	which could lead to high losses or destruction of the IC. Going below 11.5 V \n	will use the internal high-voltage generator as IC's VDD supply (higher losses).\n	So ideally, stay between 12 V and 23 V.\n\nQ: 	Where do I get a cheap high voltage source for testing?\nA: 	I have been using one for 10€ from amazon for many years, which can generate up to \n	800 V (when both -+400 V rails are used) from a 8 to 32 V source (15 V delivers most power).\n	If you want to support me, you can use my affiliate link where I get a small commission \n	when a purchase is made: https://amzn.to/3TRJJif\n	In the docs there is an additional folder 'HV Source' for a 3D-printed case which also \n	uses a rotary potentiometer instead of the trim pot. \n	\nQ: 	I need more Power!\nA: 	A smaller Inductor value could help, but be aware that the minimum on-time is 400 ns.\n	At high input voltages this could lead to overcurrent when using small inductro values.\n\nQ: 	Why is the text \"Voltage Indicator\", \"Designed by XXX\" and \"HVI vX.X\" not editable?\nA	I like to use a font (Futured) for visuals which is not pre-installed on most systems. \n	Importing it as a logo is easier to retain it. \n\nQ:	This is open source. Can I modify it? Can I sell it?\nA:	Sure! But please use your own version numbering and change \"Designed by Rootthecause\" \n	to \"Designed by [Your Name] based on a design by Rootthecause\". \n	As this is licensed under CeRN OHL v2 Weakly Reciprocal, you must disclose the source, \n	state changes and use the same license if used for non private projects.\n	Learn more about this here: https://choosealicense.com/licenses/cern-ohl-w-2.0/\n\nQ:	I've got a question not listed here, can I contact you?\nA:	Please use the issues form on GitHub for techical related questions. \n\nQ:	Is there a way to support your projects?\nA:	Yes, you can build it and share your results and findings in the GitHub forum \n     or support my project financially on Ko-Fi :) https://ko-fi.com/rootthecause"
+		(exclude_from_sim no)
+		(at 214.63 158.75 0)
+		(effects
+			(font
+				(size 0.8 0.8)
+				(thickness 0.12)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "49c1d514-d1c9-4824-afc3-51e05bd341eb")
+	)
+	(text "HV-"
+		(exclude_from_sim no)
+		(at 15.875 81.28 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "4b5a5569-de37-443c-a170-1358a8451fa9")
+	)
+	(text "5 V / 1 W max."
+		(exclude_from_sim no)
+		(at 192.405 93.98 0)
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+		)
+		(uuid "7a327438-cc20-4be4-91c7-bbc2f0d2fcde")
+	)
+	(text "The HVI (High Voltage Indicator) is used to indicate voltages above 60 V for installation in the TSAC.\nThe design shown here should comply with FS-Rules, but I'm only sure after it has passed FSG scrutineering :D\nEdit: It passed scruti.\n\nLayout: \nThe design uses the VIPER06 as a self-oscillating and self-regulating highside-switch, which corresponds to the overall topology of a buck converter.\nIn order to keep the design compact, the 60 V detection was omitted. This complies with FS-Rules, as the indicator light must light up at 60 V and above, \nbut may also light up at lower voltages. In this case, this is already the case from approx. 40 V. \nGalvanic isolation can theoretically be dispensed when mounted with an isolating housing and viewing window. \nHowever, as galvanic isolation is useful in many cases, it was implemented by using an small isolating DC/DC converter (3kV isolation rating).\nThe back of the circuit board is designed so that the LEDs do not require touch protection, as no dangerous voltage is present (isolated by PCB).\nHowever, all THT components on the back must be covered.\nAlternatively, the circuit board can be placed anywhere in the TSAC and an LED can be attached to the housing via the external output (1 W max.).\nIf the included 1 W DC/DC is not used, approx. 3 W can be drawn directly (unisolated!) at 12 V. \n\nImportant: Do not forget to isolate the board with Plastik70 after soldering (necessary due to isolation distances (EV 4.3.6 Table 5 Conformal Coating).\n\nFS-Rules 2024 v1.1 / Source: https://www.formulastudent.de/fsg/rules/\n\nT1.3.1  	Direct Connection - two devices or circuits are directly connected if the connection is not routed through any common PCB \n			and does not include any devices or functionality other than overcurrent protection or connectors.\n\nEV 1.2.1	Galvanic Isolation - two electric circuits are defined as galvanically isolated if all of the following conditions are true:\n			• The resistance between both circuits is ≥500 Ω/V, related to the maximum TS voltage of the vehicle, at a test voltage of \n			   maximum TS voltage or 250 V, whichever is higher.\n			• The isolation test voltage RMS, AC for 1 min, between both circuits is higher than three times the maximum TS voltage or 750 V, \n			   whichever is higher.\n			• The working voltage of the isolation barrier, if specified in the datasheet, is higher than the maximum TS voltage.\n\nEV 5.4.8 	Each TSAC must have a prominent indicator, a voltmeter, or a red LED visible even in bright sunlight\n 			that will illuminate whenever a voltage greater than 60 V DC or half the maximum TS voltage, whichever\n			is lower, is present at the vehicle side of the AIRs.\n\nEV 5.4.9	The indicator must be clearly visible while disconnecting the TSAC from the vehicles. The indicator \n			must be clearly marked with \"Voltage Indicator\"\n\nEV 5.4.10	The indicator must be hard-wired electronics without software control, directly and only supplied by \n			from the LVS or removed from the vehicle.\n			the TS from the vehicle side of the AIRs, and always working, even if the accumulator is disconnected \n\n\nEV 4.3.6	If TS and LVS are on the same PCB, they must be on separate well-defined areas of the board, meeting \n			the spacing requirements in table 5, each area clearly marked with \"TS\" or \"LV\". \n			The outline of the area required for spacing must be marked. \"Conformal coating\" refers to a coating \n			insulator, solder resist is not a coating.\n			Table 5: Spacing required between TS and LV -> 300 V DC to 600 V DC: 4.0 mm with conformal coating.\n\nEV 4.3.7	Teams must be prepared to demonstrate spacing on team-built equipment. For inaccessible circuitry, \n			fully assembled spare boards must be available."
+		(exclude_from_sim no)
+		(at 15.875 165.1 0)
+		(effects
+			(font
+				(size 0.8 0.8)
+				(thickness 0.12)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "809600c9-163c-434b-b209-13f05fbff4ff")
+	)
+	(text "Input Voltage"
+		(exclude_from_sim no)
+		(at 266.065 69.215 90)
+		(effects
+			(font
+				(size 0.6 0.6)
+				(thickness 0.2)
+				(bold yes)
+			)
+		)
+		(uuid "89aa16f6-c443-4ce4-8a03-da1d7be58cba")
+	)
+	(text "≤ 500 mA"
+		(exclude_from_sim no)
+		(at 28.575 35.56 0)
+		(effects
+			(font
+				(size 0.8 0.8)
+			)
+		)
+		(uuid "8fe3cf8c-8fa7-47be-a820-885ce650da48")
+	)
+	(text "Isolated output"
+		(exclude_from_sim no)
+		(at 133.985 90.805 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "9826aad6-0384-4a69-b19c-1dfceff6a118")
+	)
+	(text "5 V"
+		(exclude_from_sim no)
+		(at 153.67 81.915 0)
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+		)
+		(uuid "9f8b0157-ac99-4b6d-a3e8-2f7a029591e1")
+	)
+	(text "Note on R6 and C6\nThose are just for development.\nLeave those footprints empty."
+		(exclude_from_sim no)
+		(at 54.61 80.01 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+				(thickness 0.2)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "b2b72efa-4e3f-4114-9630-82e23c40f640")
+	)
+	(text "RC-Lowpass \nagainst ripple \nconducting \nback to TS\n\nTau = 20 µs"
+		(exclude_from_sim no)
+		(at 31.115 59.055 0)
+		(effects
+			(font
+				(size 0.8 0.8)
+				(thickness 0.16)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "b3cdae34-be41-4c43-8ce1-11c649fd8863")
+	)
+	(text "~8 mA"
+		(exclude_from_sim no)
+		(at 170.815 82.55 0)
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "bab2fe02-87c3-4eb9-beb3-3837b4d3a9ca")
+	)
+	(text "Note: F1 is made from three parts.\nF1.1 and F1.2 are the fuse clips for soldering.\nF1 is the fuse itself (insert into fuse clips)"
+		(exclude_from_sim no)
+		(at 12.7 44.45 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+				(thickness 0.16)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "c4f14073-bb95-4528-8afb-2c4f3d1eedd4")
+	)
+	(text "12 V"
+		(exclude_from_sim no)
+		(at 128.905 81.915 0)
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+		)
+		(uuid "c7109fff-2b8c-4c71-a3f4-250892186f91")
+	)
+	(text "alternative \nfootprint"
+		(exclude_from_sim no)
+		(at 163.83 88.265 0)
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+			(justify bottom)
+		)
+		(uuid "cba8bfc7-182e-467b-bb6a-e25e03439778")
+	)
+	(text "Note on JP1\nIf the output J1 is used, bridge the left and middle or right and middle pads together \nwith solder in order to choose between direct connection or resistor in series for the output."
+		(exclude_from_sim no)
+		(at 155.575 96.52 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+			)
+			(justify left)
+		)
+		(uuid "ce325d28-a2da-4714-a7a0-a86f74491dd9")
+	)
+	(text "Fuse clips"
+		(exclude_from_sim no)
+		(at 28.575 29.21 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+			)
+		)
+		(uuid "d516b1f7-c842-45ed-a890-009bbc77fa6b")
+	)
+	(text "A cartridge fuse\nfrom a multimeter \ncan be used too"
+		(exclude_from_sim no)
+		(at 22.86 40.64 0)
+		(effects
+			(font
+				(size 0.8 0.8)
+				(thickness 0.16)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "dd4b4118-4691-4a1f-811b-6e1d56f593ed")
+	)
+	(text "Important note: The minimum switch-on time for most VIPER ICs is 400 ns.\nIf the inductance (L1+L2) is too small, the current rise in these 400 ns will be too high and damage the IC.\n\nI_400ns = (U_in * 400 ns) / L\n\nU_in = 600V\nL    = 9.4 mH\n\n-> I_400ns = 25.5 mA \n\nThe drain current limit for the VIPER06 is 350 mA -> 9.4 mH is OK.\n\nThe VIPER06 IC comes in three different switching frequency versions: \nVIPER06Xx = 30 kHz\nVIPER06Lx = 60 kHz\nVIPER06Hx = 115 kHz\n\nI reccommend using the 30 kHz version, since it uses the fewest power and increases overall efficiency,\nThis version was hardly avialable in the past, but seem to be ok now (2024). \nThe other versions can be used too, but may cause audible noise in burst mode. \nBurst operation also occurs with the 30 kHz version, depending on the load.\n\nNote on capacitors: \nSome values appear quite large, but bear in mind that the capacitance of MLCCs is strongly influenced by the applied voltage.\nDepending on the manufacturer and series, the capacitance can drop by up to -90%. Check their resources! \n(Google the part number of the MLCC manufacturer and go to their website. It often contains nice diagrams :)\n\nNote on the LTSpice simulation:\nSee \"Doc\" folder. The VIPER11 is used because I could not find a Viper06 model. \nImportant: The feedback reference voltage (U_fb) for the VIPER06 is 3.3 V instead of 1.2 V (VIPER11). Adjust accordingly! \nThe VIPER11 also \"features\" a max. duty cycle counter protection, which causes a 1 second restart cycle on low input voltages\nat 12V output, but not with 5V (when used with low precharge current, see LTSpice Notes). Unless tested otherwise, \n5V and 12V output should be possible with the VIPER06. Do not forget to choose a Zener Diode approx. 1V above output voltage \nto avoid output voltage run away in no-load condition. Also choose the DC/DC (PS1) accordingly to you output voltage.\n\nSet output Voltage:\nU_out = U_fb *( 1 + R5 / R7 ) - U_D1_forward_voltage"
+		(exclude_from_sim no)
+		(at 118.11 149.86 0)
+		(effects
+			(font
+				(size 0.8 0.8)
+				(thickness 0.12)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "e7ef5d9e-3803-4582-ae9a-d25f58701cab")
+	)
+	(text "HV+"
+		(exclude_from_sim no)
+		(at 15.875 29.21 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+			)
+			(justify left bottom)
+		)
+		(uuid "fd8c63ca-3e31-44d6-ba5c-7b417ee80276")
+	)
+	(text "Note on D1\nThe US3M-13 has been replaced by the VS-E7FX0212-M3/I Didoe. \nIf you ordered the circuit board before December 14, 2024 \nthe Fooprint old will be too large.\nPlease use solder or a short wire to bridge the gap.\nUsing the US3M-13 will lead to issues with the voltage regulation."
+		(exclude_from_sim no)
+		(at 103.505 46.99 0)
+		(effects
+			(font
+				(size 0.6 0.6)
+			)
+			(justify left)
+		)
+		(uuid "ffe7e978-ee9a-4aaf-9ebf-4c7a6e7e2043")
 	)
 	(junction
 		(at 55.245 75.565)
@@ -8718,7 +9056,25 @@
 			"IECAAAECBAgQIECAAAECBAgQKAkIOJYwbBIgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAg0JqA"
 			"gGNrXkoTIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIFASEHAsYdgkQIAAAQIECBAgQIAAAQIE"
 			"CBAgQIAAAQIECBAgQKA1AQHH1ryUJkCAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECgJPB/jZiU"
-			"KqnjHOYAAAAASUVORK5CYII="
+			"KqnjHOYAAAAASUVORK5CYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANiGGbmzXQAA"
+			"aIcZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAACCHGbmzXQAAsIcZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGiHGbmzXQAA+IcZubNdAACAiNK3s10AAAAAAAAECAAAAAEA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALCHGbmzXQAAQIgZubNdAACAiNK3"
+			"s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPiHGbmz"
+			"XQAAiIgZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAECIGbmzXQAA0IgZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIiIGbmzXQAAGIkZubNdAACAiNK3s10AAAAAAAAECAAA"
+			"AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANCIGbmzXQAAYIkZubNdAACA"
+			"iNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABiJ"
+			"GbmzXQAAqIkZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAGCJGbmzXQAA8IkZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKiJGbmzXQAAOIoZubNdAACAiNK3s10AAAAAAAAE"
+			"CAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPCJGbmzXQAAgIoZubNd"
+			"AACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"ADiKGbmzXQAAyIoZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAICKGbmzXQAAEIsZubNdAACAiNK3s10AAAAAAAAECAAAAAEAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAA=="
 		)
 	)
 	(image
@@ -9074,7 +9430,25 @@
 			"KLVlvd6stryTCepyFWFa1mvOakO2/u/eAAAAGBQKLAAAgMAosAAAAAKjwAIAAAiMAgsAACAwCiwA"
 			"AIDAKLAAAAACo8ACAAAIjAILAAAgMAosAACAwCiwAAAAAqPAAgAACIwCCwAAIDAKLAAAgMAosAAA"
 			"AAKjwAIAAAiMAgsAACAwCiwAAIDAKLAAAAACo8ACAAAIjAILAAAgMAosAACAwP4/QPMiIRUrI74A"
-			"AAAASUVORK5CYII="
+			"AAAASUVORK5CYIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAA=="
 		)
 	)
 	(image
@@ -10102,292 +10476,26 @@
 			"5k4EiECtRACLBZWdCOCH/+EKoVZCwEITASJABIgAESACRIAIEAEiUBkEGsycPStq0by5NG/WvDL5"
 			"8FkiQASIABEgAkSACBABIkAEahkCVBOqZRXG4tYMBPSobytIkyZNakaBWIpqRYDyUK3w8+UFEKBs"
 			"FgCnHt6iPNTDSi/wk10eGmFXAESvKAXQ4i0ikELALfD5v0kBU0+jlId6WvG14GdTNmtBJZWwiJSH"
-			"EoJdC17l8vD/AT4tlfmTY+71AAAAAElFTkSuQmCC"
+			"EoJdC17l8vD/AT4tlfmTY+71AAAAAElFTkSuQmCCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
 		)
-	)
-	(text "Note on C11\nIf it is intend to drive a large load, \nthen you can use C11 instead."
-		(exclude_from_sim no)
-		(at 153.67 77.47 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-				(thickness 0.2)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "01fc083c-ae87-47fd-a618-378415834db0")
-	)
-	(text "I'm unsure why 700 V and 800 V look so different from the others.\nMight need to re-test when I got time :‘)"
-		(exclude_from_sim no)
-		(at 240.665 92.075 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-				(thickness 0.12)
-				(bold yes)
-			)
-		)
-		(uuid "1c91fa15-c22c-4582-8b12-0e494b25a2e4")
-	)
-	(text "Buck converter using VIPER06\n800V -> 5V/12V "
-		(exclude_from_sim no)
-		(at 15.24 24.765 0)
-		(effects
-			(font
-				(size 3 3)
-				(thickness 0.6)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "2f65ae9a-ff30-4504-9336-cdcf2f6fc423")
-	)
-	(text "FAQ:\n\nQ: 	Why are 2x 4.7 mH inductors used instead of a 10 mH inductor?\nA: 	You will rarely find maximum voltage values for SMD inductors, so just an extra precaution.\n\nQ: 	Why is there no output fuse?\nA: 	The VIPER06 can be short-circuited indefinitely.\n\nQ: 	I need [insert voltage here], can I do that?\nA: 	You can either change PS1 (12 V to 3.3 V to 24 V converters available) \n	or (when used directly without PS1) the feedback voltage divider can be altered.\n	I do not reccomend going above 23.5 V because the IC's VDD voltage will be clamped, \n	which could lead to high losses or destruction of the IC. Going below 11.5 V \n	will use the internal high-voltage generator as IC's VDD supply (higher losses).\n	So ideally, stay between 12 V and 23 V.\n\nQ: 	Where do I get a cheap high voltage source for testing?\nA: 	I have been using one for 10€ from amazon for many years, which can generate up to \n	800 V (when both -+400 V rails are used) from a 8 to 32 V source (15 V delivers most power).\n	If you want to support me, you can use my affiliate link where I get a small commission \n	when a purchase is made: https://amzn.to/3TRJJif\n	In the docs there is an additional folder 'HV Source' for a 3D-printed case which also \n	uses a rotary potentiometer instead of the trim pot. \n	\nQ: 	I need more Power!\nA: 	A smaller Inductor value could help, but be aware that the minimum on-time is 400 ns.\n	At high input voltages this could lead to overcurrent when using small inductro values.\n\nQ: 	Why is the text \"Voltage Indicator\", \"Designed by XXX\" and \"HVI vX.X\" not editable?\nA	I like to use a font (Futured) for visuals which is not pre-installed on most systems. \n	Importing it as a logo is easier to retain it. \n\nQ:	This is open source. Can I modify it? Can I sell it?\nA:	Sure! But please use your own version numbering and change \"Designed by Rootthecause\" \n	to \"Designed by [Your Name] based on a design by Rootthecause\". \n	As this is licensed under CeRN OHL v2 Weakly Reciprocal, you must disclose the source, \n	state changes and use the same license if used for non private projects.\n	Learn more about this here: https://choosealicense.com/licenses/cern-ohl-w-2.0/\n\nQ:	I've got a question not listed here, can I contact you?\nA:	Please use the issues form on GitHub for techical related questions. \n\nQ:	Is there a way to support your projects?\nA:	Yes, you can build it and share your results and findings in the GitHub forum \n     or support my project financially on Ko-Fi :) https://ko-fi.com/rootthecause"
-		(exclude_from_sim no)
-		(at 214.63 158.75 0)
-		(effects
-			(font
-				(size 0.8 0.8)
-				(thickness 0.12)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "49c1d514-d1c9-4824-afc3-51e05bd341eb")
-	)
-	(text "HV-"
-		(exclude_from_sim no)
-		(at 15.875 81.28 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(thickness 0.254)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "4b5a5569-de37-443c-a170-1358a8451fa9")
-	)
-	(text "5 V / 1 W max."
-		(exclude_from_sim no)
-		(at 192.405 93.98 0)
-		(effects
-			(font
-				(size 1 1)
-				(thickness 0.2)
-				(bold yes)
-			)
-		)
-		(uuid "7a327438-cc20-4be4-91c7-bbc2f0d2fcde")
-	)
-	(text "The HVI (High Voltage Indicator) is used to indicate voltages above 60 V for installation in the TSAC.\nThe design shown here should comply with FS-Rules, but I'm only sure after it has passed FSG scrutineering :D\nEdit: It passed scruti.\n\nLayout: \nThe design uses the VIPER06 as a self-oscillating and self-regulating highside-switch, which corresponds to the overall topology of a buck converter.\nIn order to keep the design compact, the 60 V detection was omitted. This complies with FS-Rules, as the indicator light must light up at 60 V and above, \nbut may also light up at lower voltages. In this case, this is already the case from approx. 40 V. \nGalvanic isolation can theoretically be dispensed when mounted with an isolating housing and viewing window. \nHowever, as galvanic isolation is useful in many cases, it was implemented by using an small isolating DC/DC converter (3kV isolation rating).\nThe back of the circuit board is designed so that the LEDs do not require touch protection, as no dangerous voltage is present (isolated by PCB).\nHowever, all THT components on the back must be covered.\nAlternatively, the circuit board can be placed anywhere in the TSAC and an LED can be attached to the housing via the external output (1 W max.).\nIf the included 1 W DC/DC is not used, approx. 3 W can be drawn directly (unisolated!) at 12 V. \n\nImportant: Do not forget to isolate the board with Plastik70 after soldering (necessary due to isolation distances (EV 4.3.6 Table 5 Conformal Coating).\n\nFS-Rules 2024 v1.1 / Source: https://www.formulastudent.de/fsg/rules/\n\nT1.3.1  	Direct Connection - two devices or circuits are directly connected if the connection is not routed through any common PCB \n			and does not include any devices or functionality other than overcurrent protection or connectors.\n\nEV 1.2.1	Galvanic Isolation - two electric circuits are defined as galvanically isolated if all of the following conditions are true:\n			• The resistance between both circuits is ≥500 Ω/V, related to the maximum TS voltage of the vehicle, at a test voltage of \n			   maximum TS voltage or 250 V, whichever is higher.\n			• The isolation test voltage RMS, AC for 1 min, between both circuits is higher than three times the maximum TS voltage or 750 V, \n			   whichever is higher.\n			• The working voltage of the isolation barrier, if specified in the datasheet, is higher than the maximum TS voltage.\n\nEV 5.4.8 	Each TSAC must have a prominent indicator, a voltmeter, or a red LED visible even in bright sunlight\n 			that will illuminate whenever a voltage greater than 60 V DC or half the maximum TS voltage, whichever\n			is lower, is present at the vehicle side of the AIRs.\n\nEV 5.4.9	The indicator must be clearly visible while disconnecting the TSAC from the vehicles. The indicator \n			must be clearly marked with \"Voltage Indicator\"\n\nEV 5.4.10	The indicator must be hard-wired electronics without software control, directly and only supplied by \n			from the LVS or removed from the vehicle.\n			the TS from the vehicle side of the AIRs, and always working, even if the accumulator is disconnected \n\n\nEV 4.3.6	If TS and LVS are on the same PCB, they must be on separate well-defined areas of the board, meeting \n			the spacing requirements in table 5, each area clearly marked with \"TS\" or \"LV\". \n			The outline of the area required for spacing must be marked. \"Conformal coating\" refers to a coating \n			insulator, solder resist is not a coating.\n			Table 5: Spacing required between TS and LV -> 300 V DC to 600 V DC: 4.0 mm with conformal coating.\n\nEV 4.3.7	Teams must be prepared to demonstrate spacing on team-built equipment. For inaccessible circuitry, \n			fully assembled spare boards must be available."
-		(exclude_from_sim no)
-		(at 15.875 165.1 0)
-		(effects
-			(font
-				(size 0.8 0.8)
-				(thickness 0.12)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "809600c9-163c-434b-b209-13f05fbff4ff")
-	)
-	(text "Input Voltage"
-		(exclude_from_sim no)
-		(at 266.065 69.215 90)
-		(effects
-			(font
-				(size 0.6 0.6)
-				(thickness 0.2)
-				(bold yes)
-			)
-		)
-		(uuid "89aa16f6-c443-4ce4-8a03-da1d7be58cba")
-	)
-	(text "≤ 500 mA"
-		(exclude_from_sim no)
-		(at 28.575 35.56 0)
-		(effects
-			(font
-				(size 0.8 0.8)
-			)
-		)
-		(uuid "8fe3cf8c-8fa7-47be-a820-885ce650da48")
-	)
-	(text "Isolated output"
-		(exclude_from_sim no)
-		(at 133.985 90.805 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(thickness 0.254)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "9826aad6-0384-4a69-b19c-1dfceff6a118")
-	)
-	(text "5 V"
-		(exclude_from_sim no)
-		(at 153.67 81.915 0)
-		(effects
-			(font
-				(size 1 1)
-				(thickness 0.2)
-				(bold yes)
-			)
-		)
-		(uuid "9f8b0157-ac99-4b6d-a3e8-2f7a029591e1")
-	)
-	(text "Note on R6 and C6\nThose are just for development.\nLeave those footprints empty."
-		(exclude_from_sim no)
-		(at 54.61 80.01 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-				(thickness 0.2)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "b2b72efa-4e3f-4114-9630-82e23c40f640")
-	)
-	(text "RC-Lowpass \nagainst ripple \nconducting \nback to TS\n\nTau = 20 µs"
-		(exclude_from_sim no)
-		(at 31.115 59.055 0)
-		(effects
-			(font
-				(size 0.8 0.8)
-				(thickness 0.16)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "b3cdae34-be41-4c43-8ce1-11c649fd8863")
-	)
-	(text "~8 mA"
-		(exclude_from_sim no)
-		(at 170.815 82.55 0)
-		(effects
-			(font
-				(size 1 1)
-				(thickness 0.2)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "bab2fe02-87c3-4eb9-beb3-3837b4d3a9ca")
-	)
-	(text "Note: F1 is made from three parts.\nF1.1 and F1.2 are the fuse clips for soldering.\nF1 is the fuse itself (insert into fuse clips)"
-		(exclude_from_sim no)
-		(at 12.7 44.45 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-				(thickness 0.16)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "c4f14073-bb95-4528-8afb-2c4f3d1eedd4")
-	)
-	(text "12 V"
-		(exclude_from_sim no)
-		(at 128.905 81.915 0)
-		(effects
-			(font
-				(size 1 1)
-				(thickness 0.2)
-				(bold yes)
-			)
-		)
-		(uuid "c7109fff-2b8c-4c71-a3f4-250892186f91")
-	)
-	(text "alternative \nfootprint"
-		(exclude_from_sim no)
-		(at 163.83 88.265 0)
-		(effects
-			(font
-				(size 1 1)
-				(thickness 0.2)
-				(bold yes)
-			)
-			(justify bottom)
-		)
-		(uuid "cba8bfc7-182e-467b-bb6a-e25e03439778")
-	)
-	(text "Note on JP1\nIf the output J1 is used, bridge the left and middle or right and middle pads together \nwith solder in order to choose between direct connection or resistor in series for the output."
-		(exclude_from_sim no)
-		(at 155.575 96.52 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-			)
-			(justify left)
-		)
-		(uuid "ce325d28-a2da-4714-a7a0-a86f74491dd9")
-	)
-	(text "Fuse clips"
-		(exclude_from_sim no)
-		(at 28.575 29.21 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-			)
-		)
-		(uuid "d516b1f7-c842-45ed-a890-009bbc77fa6b")
-	)
-	(text "A cartridge fuse\nfrom a multimeter \ncan be used too"
-		(exclude_from_sim no)
-		(at 22.86 40.64 0)
-		(effects
-			(font
-				(size 0.8 0.8)
-				(thickness 0.16)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "dd4b4118-4691-4a1f-811b-6e1d56f593ed")
-	)
-	(text "Important note: The minimum switch-on time for most VIPER ICs is 400 ns.\nIf the inductance (L1+L2) is too small, the current rise in these 400 ns will be too high and damage the IC.\n\nI_400ns = (U_in * 400 ns) / L\n\nU_in = 600V\nL    = 9.4 mH\n\n-> I_400ns = 25.5 mA \n\nThe drain current limit for the VIPER06 is 350 mA -> 9.4 mH is OK.\n\nThe VIPER06 IC comes in three different switching frequency versions: \nVIPER06Xx = 30 kHz\nVIPER06Lx = 60 kHz\nVIPER06Hx = 115 kHz\n\nI reccommend using the 30 kHz version, since it uses the fewest power and increases overall efficiency,\nThis version was hardly avialable in the past, but seem to be ok now (2024). \nThe other versions can be used too, but may cause audible noise in burst mode. \nBurst operation also occurs with the 30 kHz version, depending on the load.\n\nNote on capacitors: \nSome values appear quite large, but bear in mind that the capacitance of MLCCs is strongly influenced by the applied voltage.\nDepending on the manufacturer and series, the capacitance can drop by up to -90%. Check their resources! \n(Google the part number of the MLCC manufacturer and go to their website. It often contains nice diagrams :)\n\nNote on the LTSpice simulation:\nSee \"Doc\" folder. The VIPER11 is used because I could not find a Viper06 model. \nImportant: The feedback reference voltage (U_fb) for the VIPER06 is 3.3 V instead of 1.2 V (VIPER11). Adjust accordingly! \nThe VIPER11 also \"features\" a max. duty cycle counter protection, which causes a 1 second restart cycle on low input voltages\nat 12V output, but not with 5V (when used with low precharge current, see LTSpice Notes). Unless tested otherwise, \n5V and 12V output should be possible with the VIPER06. Do not forget to choose a Zener Diode approx. 1V above output voltage \nto avoid output voltage run away in no-load condition. Also choose the DC/DC (PS1) accordingly to you output voltage.\n\nSet output Voltage:\nU_out = U_fb *( 1 + R5 / R7 ) - U_D1_forward_voltage"
-		(exclude_from_sim no)
-		(at 118.11 149.86 0)
-		(effects
-			(font
-				(size 0.8 0.8)
-				(thickness 0.12)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "e7ef5d9e-3803-4582-ae9a-d25f58701cab")
-	)
-	(text "HV+"
-		(exclude_from_sim no)
-		(at 15.875 29.21 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(thickness 0.254)
-				(bold yes)
-			)
-			(justify left bottom)
-		)
-		(uuid "fd8c63ca-3e31-44d6-ba5c-7b417ee80276")
-	)
-	(text "Note on D1\nThe US3M-13 has been replaced by the VS-E7FX0212-M3/I Didoe. \nIf you ordered the circuit board before December 14, 2024 \nthe Fooprint old will be too large.\nPlease use solder or a short wire to bridge the gap.\nUsing the US3M-13 will lead to issues with the voltage regulation."
-		(exclude_from_sim no)
-		(at 103.505 46.99 0)
-		(effects
-			(font
-				(size 0.6 0.6)
-			)
-			(justify left)
-		)
-		(uuid "ffe7e978-ee9a-4aaf-9ebf-4c7a6e7e2043")
 	)
 	(symbol
 		(lib_id "Device:R_Small")
@@ -10602,6 +10710,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "604-APTD1608LSURCK"
+			(at 190.5 79.375 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C5342734"
+			(at 190.5 79.375 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "4c056917-df8b-44ab-969e-b5ea183c1c55")
 		)
@@ -10708,6 +10834,24 @@
 			)
 		)
 		(property "Manufacturer Number" "AC0603JR-0710KL"
+			(at 74.295 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "603-AC0603JR-0710KL"
+			(at 74.295 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C25804"
 			(at 74.295 69.215 0)
 			(effects
 				(font
@@ -10830,6 +10974,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "81-GRM188R6YA106MA3J"
+			(at 158.75 81.915 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C22367827"
+			(at 158.75 81.915 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "b8dbf74e-c918-4387-b88d-410d06bc474d")
 		)
@@ -10937,6 +11099,24 @@
 			)
 		)
 		(property "Manufacturer Number" "GRM188R72A103MA01J"
+			(at 80.01 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "81-GRM188R72A103MA1J"
+			(at 80.01 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
 			(at 80.01 63.5 0)
 			(effects
 				(font
@@ -11100,6 +11280,23 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "490-PEME1-S12-S5-S"
+			(at 141.605 81.915 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
+			(at 141.605 81.915 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "5fb76dad-57f1-4131-a970-781f29fe0655")
 		)
@@ -11210,6 +11407,24 @@
 			)
 		)
 		(property "Manufacturer Number" "KTR18EZPF2700"
+			(at 38.735 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "755-KTR18EZPF2700"
+			(at 38.735 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C4466"
 			(at 38.735 45.72 0)
 			(effects
 				(font
@@ -11413,6 +11628,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "576-01220083Z"
+			(at 32.385 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C206901"
+			(at 32.385 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "614b08d8-7a1f-4039-8acc-73b9930d44d6")
 		)
@@ -11514,6 +11747,24 @@
 			)
 		)
 		(property "Manufacturer Number" "US3M-13"
+			(at 80.01 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "621-US3M-13 "
+			(at 80.01 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C2934846"
 			(at 80.01 80.01 0)
 			(effects
 				(font
@@ -11635,6 +11886,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "604-APTD1608LSURCK"
+			(at 182.88 79.375 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C5342734"
+			(at 182.88 79.375 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "12b9658a-e506-4a0f-8961-78f3212ca24f")
 		)
@@ -11741,6 +12010,24 @@
 			)
 		)
 		(property "Manufacturer Number" "VIPER06XS"
+			(at 57.785 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "511-VIPER06XSTR"
+			(at 57.785 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C2845040"
 			(at 57.785 39.37 0)
 			(effects
 				(font
@@ -11885,6 +12172,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "652-SRR1208-472KL"
+			(at 95.885 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
+			(at 95.885 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "6631145f-b0fb-407e-85e9-19bbb524f90b")
 		)
@@ -11991,6 +12296,24 @@
 			)
 		)
 		(property "Manufacturer Number" "CRCW06031K00FKEE"
+			(at 68.58 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "71-CRCW06031K00FKEE"
+			(at 68.58 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C21190"
 			(at 68.58 59.055 0)
 			(effects
 				(font
@@ -12111,6 +12434,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "755-KTR18EZPF2700"
+			(at 38.735 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C4466"
+			(at 38.735 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "0366fe24-965c-4de9-9de9-d844093f8494")
 		)
@@ -12223,6 +12564,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "78-VS-E7FX0212-M3/I "
+			(at 114.3 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
+			(at 114.3 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "66eb8896-620d-478c-b45d-602f44d8d49c")
 		)
@@ -12327,6 +12686,24 @@
 			)
 		)
 		(property "Manufacturer Number" "SRR1208-472KL"
+			(at 87.63 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "652-SRR1208-472KL"
+			(at 87.63 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
 			(at 87.63 75.565 0)
 			(effects
 				(font
@@ -12451,6 +12828,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "538-43650-0215"
+			(at 17.145 85.725 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C293740"
+			(at 17.145 85.725 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "c2916be5-d66f-42d3-8901-3f96ebcde002")
 		)
@@ -12565,6 +12960,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "80-C0603C223J3RAUTO"
+			(at 68.58 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C302020"
+			(at 68.58 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "172508ba-ebf6-4bf0-a438-0a8ca1e40844")
 		)
@@ -12671,6 +13084,24 @@
 			)
 		)
 		(property "Manufacturer Number" "C5750X7R2J224K230KA"
+			(at 42.545 53.975 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "810-C5750X7R2J224K"
+			(at 42.545 53.975 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C1919667"
 			(at 42.545 53.975 0)
 			(effects
 				(font
@@ -12911,6 +13342,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "603-AC0603FR-0727KL"
+			(at 74.295 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C21190"
+			(at 74.295 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "65c805e5-c9a5-440a-9e39-3c168cd9fb39")
 		)
@@ -13015,6 +13464,24 @@
 			)
 		)
 		(property "Manufacturer Number" "KTR18EZPF2700"
+			(at 38.735 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "755-KTR18EZPF2700"
+			(at 38.735 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C4466"
 			(at 38.735 39.37 0)
 			(effects
 				(font
@@ -13129,6 +13596,24 @@
 			)
 		)
 		(property "Manufacturer Number" "MCASE32MAB5476MPNDTJ"
+			(at 109.855 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "963-E32MAB5476MPNDTJ"
+			(at 109.855 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C2361249"
 			(at 109.855 80.01 0)
 			(effects
 				(font
@@ -13365,6 +13850,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "652-P6SMB13A"
+			(at 114.3 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C1972922"
+			(at 114.3 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "59040474-1546-4afc-b4ec-e88e1b314826")
 		)
@@ -13469,6 +13972,24 @@
 			)
 		)
 		(property "Manufacturer Number" "RC0201FR-074K7L"
+			(at 120.015 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "603-RC0201FR-074K7L"
+			(at 120.015 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
 			(at 120.015 80.01 0)
 			(effects
 				(font
@@ -13582,6 +14103,24 @@
 			)
 		)
 		(property "Manufacturer Number" "AC0603FR-10150RL"
+			(at 173.355 79.375 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "603-AC0603FR-10150RL"
+			(at 173.355 79.375 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C114608"
 			(at 173.355 79.375 0)
 			(effects
 				(font
@@ -13704,6 +14243,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "604-APTD1608LSURCK"
+			(at 120.015 70.485 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C5342734"
+			(at 120.015 70.485 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "8ba2b912-7e31-42c1-ac8b-e4e03c27f98b")
 		)
@@ -13817,6 +14374,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "530-0ADAC0250-BE"
+			(at 28.575 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "X"
+			(at 28.575 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "cb71daa8-8cd2-41e9-834d-d10544add560")
 		)
@@ -13921,6 +14496,24 @@
 			)
 		)
 		(property "Manufacturer Number" "US3M-13"
+			(at 124.46 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "621-US3M-13 "
+			(at 124.46 59.055 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C2934846"
 			(at 124.46 59.055 0)
 			(effects
 				(font
@@ -14044,6 +14637,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "538-43650-0215"
+			(at 17.145 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C293740"
+			(at 17.145 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "0b13d16f-1af4-4e76-8e3b-3b4b47d96c78")
 		)
@@ -14115,6 +14726,24 @@
 			)
 		)
 		(property "Manufacturer Number" "01220083Z "
+			(at 24.765 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "576-01220083Z"
+			(at 24.765 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C206901"
 			(at 24.765 27.94 0)
 			(effects
 				(font
@@ -14227,6 +14856,24 @@
 			)
 		)
 		(property "Manufacturer Number" "43650-0215"
+			(at 182.88 90.805 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser" "538-43650-0215"
+			(at 182.88 90.805 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C293740"
 			(at 182.88 90.805 0)
 			(effects
 				(font
@@ -14349,6 +14996,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "963-UMK107BBJ225KA-T"
+			(at 55.245 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C913904"
+			(at 55.245 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "b41bd710-7855-452c-94b8-1e9234c621a4")
 		)
@@ -14463,6 +15128,24 @@
 				(hide yes)
 			)
 		)
+		(property "Mouser" "963-E32MAB5476MPNDTJ"
+			(at 103.505 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C2361249"
+			(at 103.505 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
 		(pin "1"
 			(uuid "407b8c9e-f75e-474d-a960-c20f19d8ff84")
 		)
@@ -14483,4 +15166,5 @@
 			(page "1")
 		)
 	)
+	(embedded_fonts no)
 )


### PR DESCRIPTION
Hello again! 
I added easily identifiable Mouser and LCSC IDs to the BOM. 
The Mouser numbers are confirmed good but the LCSC ones are missing quite a few items.
I also updated the Files to KiCad 9